### PR TITLE
Update sbt-codeartifact warning and error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.class
 *.log
+.idea
 **/out/
 **/.bloop/
 **/.bsp/

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,4 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=8.0.412-kona
+sbt=1.9.7

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # SBT CodeArtifact
 
-[![Maven][maven]][mavenlink]
-
-[maven]: https://maven-badges.herokuapp.com/maven-central/io.github.bbstilson/sbt-codeartifact/badge.svg?kill_cache=1&color=blue&style=for-the-badge
-[mavenlink]: https://search.maven.org/search?q=g:io.github.bbstilson%20AND%20a:sbt-codeartifact
-
 An sbt plugin for publishing/consuming packages to/from AWS CodeArtifact.
 
 ## Install
@@ -12,7 +7,7 @@ An sbt plugin for publishing/consuming packages to/from AWS CodeArtifact.
 First, you will need a CodeArtifact repository. Then, add the following to your sbt `project/plugins.sbt` file:
 
 ```scala
-addSbtPlugin("io.github.bbstilson" % "sbt-codeartifact" % version)
+addSbtPlugin("com.iterable" % "sbt-codeartifact" % version)
 ```
 
 ## Usage

--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,8 @@
 inThisBuild(
   List(
-    organization := "io.github.bbstilson",
-    homepage := Some(url("https://github.com/bbstilson/sbt-codeartifact")),
-    licenses := Seq("MIT" -> url("https://choosealicense.com/licenses/mit/")),
-    developers := List(
-      Developer(
-        "bbstilson",
-        "Brandon Stilson",
-        "bbstilson@fastmail.com",
-        url("https://github.com/bbstilson")
-      )
-    )
+    organization := "com.iterable",
+    homepage := Some(url("https://github.com/Iterable/sbt-codeartifact")),
+    licenses := Seq("MIT" -> url("https://choosealicense.com/licenses/mit/"))
   )
 )
 

--- a/core/src/main/scala/codeartifact/CodeArtifact.scala
+++ b/core/src/main/scala/codeartifact/CodeArtifact.scala
@@ -1,8 +1,5 @@
 package codeartifact
 
-import software.amazon.awssdk.services.codeartifact.CodeartifactClient
-import software.amazon.awssdk.services.codeartifact.model.GetAuthorizationTokenRequest
-
 import sbt._
 import scala.concurrent.duration._
 
@@ -14,23 +11,6 @@ object CodeArtifact {
     host = repo.host,
     passwd = token
   )
-
-  private def getAuthorizationTokenRequest(domain: String, owner: String) =
-    GetAuthorizationTokenRequest
-      .builder()
-      .domain(domain)
-      .domainOwner(owner)
-      .durationSeconds(15.minutes.toSeconds)
-      .build()
-
-  private def getAuthTokenFromRequest(req: GetAuthorizationTokenRequest): String =
-    CodeartifactClient
-      .create()
-      .getAuthorizationToken(req)
-      .authorizationToken()
-
-  def getAuthToken(repo: CodeArtifactRepo): String =
-    getAuthTokenFromRequest(getAuthorizationTokenRequest(repo.domain, repo.owner))
 
   object Defaults {
     val READ_TIMEOUT: Int = 1.minutes.toMillis.toInt

--- a/core/src/main/scala/codeartifact/CodeArtifact.scala
+++ b/core/src/main/scala/codeartifact/CodeArtifact.scala
@@ -1,5 +1,8 @@
 package codeartifact
 
+import software.amazon.awssdk.services.codeartifact.CodeartifactClient
+import software.amazon.awssdk.services.codeartifact.model.GetAuthorizationTokenRequest
+
 import sbt._
 import scala.concurrent.duration._
 
@@ -11,6 +14,23 @@ object CodeArtifact {
     host = repo.host,
     passwd = token
   )
+
+  private def getAuthorizationTokenRequest(domain: String, owner: String) =
+    GetAuthorizationTokenRequest
+      .builder()
+      .domain(domain)
+      .domainOwner(owner)
+      .durationSeconds(15.minutes.toSeconds)
+      .build()
+
+  private def getAuthTokenFromRequest(req: GetAuthorizationTokenRequest): String =
+    CodeartifactClient
+      .create()
+      .getAuthorizationToken(req)
+      .authorizationToken()
+
+  def getAuthToken(repo: CodeArtifactRepo): String =
+    getAuthTokenFromRequest(getAuthorizationTokenRequest(repo.domain, repo.owner))
 
   object Defaults {
     val READ_TIMEOUT: Int = 1.minutes.toMillis.toInt

--- a/sbt-codeartifact/src/main/scala/codeartifact/CodeArtifactKeys.scala
+++ b/sbt-codeartifact/src/main/scala/codeartifact/CodeArtifactKeys.scala
@@ -28,7 +28,7 @@ trait InternalCodeArtifactKeys {
   val codeArtifactRepo = taskKey[CodeArtifactRepo]("CodeArtifact repository.")
   val codeArtifactPackage = taskKey[CodeArtifactPackage]("CodeArtifact package.")
 
-  val codeArtifactToken = taskKey[String](
+  val codeArtifactToken = taskKey[Option[String]](
     "CodeArtifact authentication. Provided by environment variable CODEARTIFACT_AUTH_TOKEN or fetched dynamically from available AWS credentials."
   )
 }

--- a/sbt-codeartifact/src/main/scala/codeartifact/CodeArtifactPlugin.scala
+++ b/sbt-codeartifact/src/main/scala/codeartifact/CodeArtifactPlugin.scala
@@ -16,6 +16,8 @@ object CodeArtifactPlugin extends AutoPlugin {
 
   object autoImport extends CodeArtifactKeys
 
+  val codeArtifactAuthToken = sys.env.getOrElse("CODEARTIFACT_AUTH_TOKEN", "")
+
   def buildPublishSettings: Seq[Setting[_]] = Seq(
     ThisBuild / codeArtifactUrl := "",
     ThisBuild / codeArtifactResolvers := Nil
@@ -24,14 +26,7 @@ object CodeArtifactPlugin extends AutoPlugin {
   def codeArtifactSettings: Seq[Setting[_]] = Seq(
     codeArtifactPublish := dynamicallyPublish.value,
     codeArtifactRepo := CodeArtifactRepo.fromUrl(codeArtifactUrl.value),
-    codeArtifactToken := sys.env
-      .get("CODEARTIFACT_AUTH_TOKEN")
-      .orElse(
-        Credentials.loadCredentials(Path.userHome / ".sbt" / "credentials").toOption.map(_.passwd)
-      )
-      .getOrElse(
-        CodeArtifact.getAuthToken(codeArtifactRepo.value)
-      ),
+    codeArtifactToken := codeArtifactAuthToken,
     codeArtifactConnectTimeout := CodeArtifact.Defaults.CONNECT_TIMEOUT,
     codeArtifactReadTimeout := CodeArtifact.Defaults.READ_TIMEOUT,
     codeArtifactPackage := CodeArtifactPackage(

--- a/sbt-codeartifact/src/sbt-test/sbt-codeartifact/appends-creds/project/plugins.sbt
+++ b/sbt-codeartifact/src/sbt-test/sbt-codeartifact/appends-creds/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.github.bbstilson" % "sbt-codeartifact" % System.getProperty("plugin.version"))
+addSbtPlugin("com.iterable" % "sbt-codeartifact" % System.getProperty("plugin.version"))

--- a/sbt-codeartifact/src/sbt-test/sbt-codeartifact/do-not-wait-for-skip/project/plugins.sbt
+++ b/sbt-codeartifact/src/sbt-test/sbt-codeartifact/do-not-wait-for-skip/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.github.bbstilson" % "sbt-codeartifact" % System.getProperty("plugin.version"))
+addSbtPlugin("com.iterable" % "sbt-codeartifact" % System.getProperty("plugin.version"))

--- a/sbt-codeartifact/src/sbt-test/sbt-codeartifact/resolver/project/plugins.sbt
+++ b/sbt-codeartifact/src/sbt-test/sbt-codeartifact/resolver/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.github.bbstilson" % "sbt-codeartifact" % System.getProperty("plugin.version"))
+addSbtPlugin("com.iterable" % "sbt-codeartifact" % System.getProperty("plugin.version"))


### PR DESCRIPTION
## Changes
This pr makes the following changes:
- Update the plugin to only support adding the auth token by using the `CODEARTIFACT_AUTH_TOKEN` env var.
- Evaluate the the token once. Currently, it is getting the token for each sub project. For a multi project build there will be an error/warning for each sub project if the `CODEARTIFACT_AUTH_TOKEN` env var is not set.
- Update the plugin to only warn when the `CODEARTIFACT_AUTH_TOKEN` env var is not set when pulling dependencies.
- Update the plugin to error when the `CODEARTIFACT_AUTH_TOKEN` env var is not set when publishing dependencies.
- Adds sdkman setup for easier env setup.
- Update the project to use the iterable namespace.

## Examples
Running `sbt compile` without the `CODEARTIFACT_AUTH_TOKEN` defined will now generate the following warning:
```
[warn]  Unable to get AWS CodeArtifact auth token.
```

Running `sbt codeArtifactPublish` without the `CODEARTIFACT_AUTH_TOKEN` defined will now generate the following error:
```
[error] java.lang.RuntimeException: Failed to publish to AWS Codeartifact because the auth token was not set.
[error] 	at codeartifact.CodeArtifactPlugin$.$anonfun$publish0$2(CodeArtifactPlugin.scala:82)
[error] 	at scala.Option.getOrElse(Option.scala:189)
[error] 	at codeartifact.CodeArtifactPlugin$.$anonfun$publish0$1(CodeArtifactPlugin.scala:81)
[error] 	at codeartifact.CodeArtifactPlugin$.$anonfun$publish0$1$adapted(CodeArtifactPlugin.scala:78)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:63)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:69)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:283)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:24)
[error] 	at sbt.Execute.work(Execute.scala:292)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:283)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:65)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[error] 	at java.base/java.lang.Thread.run(Thread.java:829)
[error] (codeArtifactPublish) Failed to publish to AWS Codeartifact because the auth token was not set in the CODEARTIFACT_AUTH_TOKEN environment variable.
```