### PR TITLE
Update release to only run on tags.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 on:
   push:
-    branches: [main]
-    tags: ["*"]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
 jobs:
   publish:
     runs-on: ubuntu-20.04

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,12 @@
 # Releasing
 
-Releases are handled by [`sbt-ci-release`](https://github.com/olafurpg/sbt-ci-release) and [Github Actions](../.github/workflows/release.yml). Random versions are automatically deployed when changes are merged to main. To create a new semvar'ed version, do the following:
+Releases are handled by [`sbt-ci-release`](https://github.com/olafurpg/sbt-ci-release) and [Github Actions](../.github/workflows/release.yml). To release a new version do the following:
 
-```bash
-git tag -a v0.1.0
-# add notes about what changed
-git push origin v0.1.0
-```
+1. Go [here](https://github.com/Iterable/sbt-codeartifact/releases/new)
+2. In the `Choose a tag` dropdown, create a new tag with the following format `v[0-9]+.[0-9]+.[0-9]`. For example `v0.0.1` is a valid release number but `0.0.1` and `0.1` are not.
+3. Make sure the `Target` branch is set correctly.
+4. Select the correct `Previous tag`.
+5. Click the `Generate release notes` button.
+6. Click the `Publish release` button.
+
+Once this is done it will trigger a github action that will publish this version to maven central.


### PR DESCRIPTION
Currently, this is trying to publish a snapshot to maven central when a new commit is pushed to master. This publish is failing. This pr updates it to only publish to maven central when creating a new tag is the correct format and it updates the documentation on how to release.
